### PR TITLE
fix: connection's lastActiveTime may be zero value when heartbeat check

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -20,6 +20,7 @@ type Connection struct {
 }
 
 func (c *Connection) open() {
+	c.lastActiveTime = time.Now()
 	go c.reader()
 	go c.writer()
 	go c.heartbeatChecker.start()


### PR DESCRIPTION
This will cause the heartbeat to incorrectly identify that a new connection has died.